### PR TITLE
fix: skip separator when decoding room name

### DIFF
--- a/adapter/redis-adapter.go
+++ b/adapter/redis-adapter.go
@@ -181,10 +181,17 @@ func (r *redisAdapter) onmessage(pattern string, channel string, msg []byte) {
 		return
 	}
 
-	room := channel[len(r.channel):]
-	if room != "" && !r.hasRoom(socket.Room(room)) {
-		redis_log.Debug("ignore unknown room %s", room)
-		return
+	if len(r.channel) < len(channel) {
+		if !strings.HasSuffix(channel, "#") {
+			redis_log.Debug("ignore invalid channel %s", channel)
+			return
+		}
+
+		room := channel[len(r.channel):len(channel)-1]
+		if !r.hasRoom(socket.Room(room)) {
+			redis_log.Debug("ignore unknown room %s", room)
+			return
+		}
 	}
 
 	var args *_types.Packet


### PR DESCRIPTION
Redis adapter [sends broadcasts](https://github.com/zishang520/socket.io-go-redis/blob/5677a86d933d468e443652e384bc853fc18b9ef5/adapter/redis-adapter.go#L618) to room `roomName` using channel `socket.io-request#/namespace#roomName#`, and then when this message is received, the last `#` [is not skipped](https://github.com/zishang520/socket.io-go-redis/blob/5677a86d933d468e443652e384bc853fc18b9ef5/adapter/redis-adapter.go#L184), so `room = "roomName#"` and the message doesn't get delivered to the correct room.

This pull request fixes this on receiving side.